### PR TITLE
make comment parser rule work with multiline comments

### DIFF
--- a/lib/pgn/parser.rb
+++ b/lib/pgn/parser.rb
@@ -86,7 +86,8 @@ module PGN
         (
           [[:print:]&&[^\\\}]] |   # printing characters except closing brace and backslash
           \\\\                 |   # escaped backslashes
-          \\\}|\\\}                # escaped braces
+          \\\}|\\\}            |   # escaped braces
+          \n                       # newlines
         )*                         # zero or more of the above
         \}                         # end of comment
       }x

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -37,8 +37,16 @@ describe PGN do
     end
 
     describe "parsing a file" do
-      it "should return a list of games" do
+      it "should work with comments" do
         games = PGN.parse(File.read("./spec/pgn_files/comments.pgn"))
+        game = games.first
+        game.tags["White"].should == "Scholar"
+        game.result.should == "1-0"
+        game.moves.last.should == "Qxf7#"
+      end
+
+      it "should work with multiline comments" do
+        games = PGN.parse(File.read("./spec/pgn_files/multiline_comments.pgn"))
         game = games.first
         game.tags["White"].should == "Scholar"
         game.result.should == "1-0"

--- a/spec/pgn_files/multiline_comments.pgn
+++ b/spec/pgn_files/multiline_comments.pgn
@@ -1,0 +1,5 @@
+[White "Scholar"]
+[Black "Somebody else"]
+
+1. e4 e5 2. Qh5 Nc6 3. Bc4 Nf6 {I pity
+the fool!} 4. Qxf7# 1-0


### PR DESCRIPTION
I tried parsing a PGN file that contained a comment spanning multiple lines and got an exception. I modified the comment rule that you added to include newlines, which works for my case, but let me know if this could have any side effects.
